### PR TITLE
Fixed Drivetrain error

### DIFF
--- a/src/main/java/org/team555/Crescendo.java
+++ b/src/main/java/org/team555/Crescendo.java
@@ -37,8 +37,8 @@ public class Crescendo extends RobotContainer
     
     @Override
     public void initialize() {
-
-        drivetrain.setDefaultCommand(); // TODO why is there no default method supplied for this function? - rechs
+        //commands.run that (if driver station is teleop, ) if isnt teleop, set speeds to 000. if not auto, call set input with controller input
+        // drivetrain.setDefaultCommand(); // TODO why is there no default method supplied for this function? - rechs
         // SHOOTER BINDINGS
         operatorController.getButton(Button.A_CROSS).onTrue(Commands555.shoot());
         operatorController.getButton(Button.X_SQUARE).onTrue(Commands555.stopShooter());

--- a/src/main/java/org/team555/components/managers/GyroscopeNavX.java
+++ b/src/main/java/org/team555/components/managers/GyroscopeNavX.java
@@ -54,7 +54,7 @@ public class GyroscopeNavX extends ManagerBase
 
     public double getPitch() {return navx.getPitch() - 1.7;} // TODO Is this offset still correct?
     public double getRoll()  {return navx.getRoll();}
-    public double getYaw() {return navx.getYaw();} // TODO This method was missing so I added it. Possible it's incorrect. - Rechs
+    
     LinearFilter avg = LinearFilter.movingAverage(20);
     double rollRate = 0;
 

--- a/src/main/java/org/team555/components/subsystems/Drivetrain.java
+++ b/src/main/java/org/team555/components/subsystems/Drivetrain.java
@@ -116,7 +116,7 @@ public class Drivetrain extends ManagerSubsystemBase {
     }
 
     public Rotation2d getRobotRotation() {
-        return Crescendo.gyroscope.getRotation2d(); // TODO: getRotation2d may have to be rewritten.
+        return Crescendo.gyroscope.getRotation2d(); // TODO: getRotation2d may have to be rewritten
     }
 
     public ChassisSpeeds getSpeedsFromMode(double omega, double x, double y) {

--- a/src/main/java/org/team555/components/subsystems/Drivetrain.java
+++ b/src/main/java/org/team555/components/subsystems/Drivetrain.java
@@ -116,7 +116,7 @@ public class Drivetrain extends ManagerSubsystemBase {
     }
 
     public Rotation2d getRobotRotation() {
-        return Rotation2d.fromDegrees(Crescendo.gyroscope.getYaw()); // TODO THIS IS PROBABLY WRONG, refer to declaraton of getYaw in GyroscopeNavX.java - rechs
+        return Crescendo.gyroscope.getRotation2d(); // TODO: getRotation2d may have to be rewritten.
     }
 
     public ChassisSpeeds getSpeedsFromMode(double omega, double x, double y) {


### PR DESCRIPTION
fixed getRobotRotation() method in Drivetrain subsystem.

replaced with gyroscope.getRotation2d(); 

function may have to be rewritten in the future.